### PR TITLE
Remove unneccesary things in AndroidManifest.xml

### DIFF
--- a/easyswipemenulibrary/src/main/AndroidManifest.xml
+++ b/easyswipemenulibrary/src/main/AndroidManifest.xml
@@ -2,10 +2,7 @@
 
     package="com.guanaj.easyswipemenulibrary">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application>
 
     </application>
 


### PR DESCRIPTION
Including these properties will cause potential AndroidManifest.xml errors, and are unneeded.